### PR TITLE
[FEAT] Fix incorrect behaviour of refill prev command

### DIFF
--- a/src/main/java/seedu/address/history/InputHistoryManager.java
+++ b/src/main/java/seedu/address/history/InputHistoryManager.java
@@ -7,7 +7,7 @@ import java.util.List;
  * A class to record the commands entered by the user
  */
 public class InputHistoryManager implements InputHistory {
-    private static final int INIT_INPUT_INDEX_VALUE = 0;
+    private static final int INIT_INPUT_INDEX_VALUE = 1;
 
     private List<String> previousInputs;
     private int indexPointer;
@@ -27,7 +27,7 @@ public class InputHistoryManager implements InputHistory {
     @Override
     public void storeInput(String input) {
         this.previousInputs.add(input);
-        indexPointer = maxInputIndex();
+        indexPointer = maxInputIndex() + 1;
     }
 
     /**

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -49,8 +49,8 @@ public class CommandBox extends UiPart<Region> {
         }
 
         // gets the last user input, then fills the text field with it
-        String prevUserInput = inputHistory.getNextUserInput();
-        commandTextField.setText(prevUserInput);
+        String nextUserInput = inputHistory.getNextUserInput();
+        commandTextField.setText(nextUserInput);
 
         // consumes the up keypress event
         keyEvent.consume();


### PR DESCRIPTION
Pressing "UP" currently when trying to reach a previous command leads to
the command textbox filling with the 2nd previous command.

Lets fix the behaviour to the command textbox filling the 1st previous
command entered