### PR TITLE
Fix up arrow symbol in User Guide

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -408,7 +408,7 @@ Format: `clear`
 
 | Button    | Result                                                               |
 |-----------|----------------------------------------------------------------------|
-| &uparrow; | Refills command textbox with previous entered command                |
+| &#8593; | Refills command textbox with previous entered command                |
 | &downarrow; | Refills command textbox with the command entered after the current one |
 
 Example:


### PR DESCRIPTION
github.io markdown does not accurately reflect the up arrow symbol with the values given. Lets update the values such that github.io will accurately reflect these symbols